### PR TITLE
[accelergyERT] Add support for design file format 0.2

### DIFF
--- a/accelergy/utils.py
+++ b/accelergy/utils.py
@@ -167,3 +167,7 @@ def INFO(*argv):
         else:
             msg_str += arg + ' '
     print(msg_str)
+
+def ASSERT_MSG(expression, msg):
+    if not expression:
+        ERROR_CLEAN_EXIT(msg);

--- a/examples/hierarchy/input/design_v0.2.yaml
+++ b/examples/hierarchy/input/design_v0.2.yaml
@@ -1,0 +1,41 @@
+# design description
+architecture:
+# ============================================================
+# Architecture Description
+# ============================================================
+  version: 0.2
+  subtree:
+    name: hierarchy            # top-level name key has the value as your design name, there can be only one component is the top level list, whic is the design
+    attributes:                # shared attributes for all subcomponents in design
+      technology: 65nm
+      voltage: 1
+    local:                     # list of components in this level
+      - name: weights_glb
+        class: shared_smartbuffer     # class signifies that this is a leaf node, i.e., component
+        attributes:            # hardware attributes that are different from default values
+          word_width: 16
+          n_words: 4
+          width: word_width * n_words # arithmetic expressions (amongst its own attributes, including projected ones, space does not matter)
+          depth: 5600
+          nbanks: 25
+          bank_depth: depth/nbanks
+          bank_width: word_width
+    subtree:                 # internal nodes in parallel with local nodes
+      name: PE[5]
+      attributes:
+        datawidth: 16
+      local:                 # list of components under each PE
+        - name: ifmap_sp
+          class: smartbuffer
+          attributes:
+            width: 16
+            depth: 256
+        - name: mac[2]
+          class: mac         # default attributes should be applied
+
+compound_components:
+  version: 0.1
+  classes:
+    - !include components/smartbuffer.yaml
+    - !include components/shared_SRAM.yaml
+    - !include components/shared_smartbuffer.yaml


### PR DESCRIPTION
This new format lets user to describe the design hierarchy more
accurately. Now each node will has two sub-nodes:

1. local: a list of defined components (compound/primitive)
2. subtree: a dict of lower-level design hierarchy

See examples/hierarchy/input/design_v0.2.yaml
for an example design file that produce the same result as the original
v0.1 design file examples/hierarchy/input/design.yaml

v0.1 is still supported.