### PR TITLE
[setup.py] Automatically install avaialble open-source plugins

### DIFF
--- a/install_plug-in.sh
+++ b/install_plug-in.sh
@@ -1,0 +1,15 @@
+InstallPath=$1 # something like ~/.local/
+cd $InstallPath/share/accelergy/estimation_plug_ins/
+echo "Cloning plug-ins"
+echo "$InstallPath/share/accelergy/estimation_plug_ins/"
+echo "Cloning Aladdin plug-in"
+git clone https://github.com/nelliewu95/accelergy-aladdin-plug-in.git
+echo "Cloning CACTI plug-in"
+git clone https://github.com/nelliewu95/accelergy-cacti-plug-in.git
+cd accelergy-cacti-plug-in
+echo "Cloning CACTI"
+git clone https://github.com/HewlettPackard/cacti.git
+cd cacti
+echo "Building CACTI"
+make -j2
+echo "Done cloning plug-ins"

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,28 @@
 from setuptools import setup
+from setuptools.command.install_scripts import install_scripts
+import subprocess
 import os
+
+class InstallCommand(install_scripts):
+    """A custom install_scripts setup to install accelergy plug-ins too."""
+    """This happens at the later stage after plug-in dir is created."""
+    def run(self):
+        print("Installing extra plugins.")
+        try:
+            tmp = subprocess.call([
+                "bash",
+                "install_plug-in.sh",
+                "/".join(self.install_dir.split("/")[:-1])]) # take out the /bin part
+        except:
+            print("Extra plugin installation failed.")
+        install_scripts.run(self)
 
 def readme():
       with open('README.md') as f:
             return f.read()
 
-setup(
-    name='accelergy',
+setup(cmdclass={'install_scripts' : InstallCommand},
+      name='accelergy',
       version='0.1',
       description='Accelergy Estimation Framework',
       classifiers=[


### PR DESCRIPTION
Calling "pip3 install ." will also install avaialble plugins (clone
github repos, build the nessesary source code, and install them in
the estimation plugins).

Currently, we have two avaialble plugins: one estimate SRAM energy using
CACTI, the other estimate data path unit with Aladdin estimations.

If in the future there are more plugins, we can modify the
"install_plug-in.sh" to include more plugins.